### PR TITLE
Decimal point fix

### DIFF
--- a/source/Assets/Scripts/InfinarioSDK/MiniJSON.cs
+++ b/source/Assets/Scripts/InfinarioSDK/MiniJSON.cs
@@ -31,6 +31,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Globalization;
 
 namespace Infinario.MiniJSON {
 	// Example usage:
@@ -525,7 +526,7 @@ namespace Infinario.MiniJSON {
 				// They always have, I'm just letting you know.
 				// Previously floats and doubles lost precision too.
 				if (value is float) {
-					builder.Append(((float) value).ToString("R"));
+					builder.Append(((float) value).ToString("R", CultureInfo.InvariantCulture));
 				} else if (value is int
 				           || value is uint
 				           || value is long
@@ -537,7 +538,7 @@ namespace Infinario.MiniJSON {
 					builder.Append(value);
 				} else if (value is double
 				           || value is decimal) {
-					builder.Append(Convert.ToDouble(value).ToString("R"));
+					builder.Append(Convert.ToDouble(value).ToString("R", CultureInfo.InvariantCulture));
 				} else {
 					SerializeString(value.ToString());
 				}


### PR DESCRIPTION
Decimal point fix - converting numbers to string using Invariant
culture, with “R” parameter. This prevents decimal numbers from using
“,” as decimal separator instead of “.”, which caused problems when
converting timestamps to JSON.
